### PR TITLE
RXI-880 fix shutdown issues

### DIFF
--- a/src/xbwd/app/App.cpp
+++ b/src/xbwd/app/App.cpp
@@ -39,7 +39,8 @@ BasicApp::~BasicApp()
     work_.reset();
     io_service_.stop();
     for (auto& t : threads_)
-        t.join();
+        if (t.joinable())
+            t.join();
 }
 
 App::App(

--- a/src/xbwd/client/ChainListener.cpp
+++ b/src/xbwd/client/ChainListener.cpp
@@ -65,11 +65,6 @@ ChainListener::ChainListener(
 {
 }
 
-// destructor must be defined after WebsocketClient size is known (i.e. it can
-// not be defaulted in the header or the unique_ptr declaration of
-// WebsocketClient won't work)
-ChainListener::~ChainListener() = default;
-
 void
 ChainListener::init(boost::asio::io_service& ios, beast::IP::Endpoint const& ip)
 {
@@ -151,7 +146,11 @@ void
 ChainListener::shutdown()
 {
     if (wsClient_)
+    {
         wsClient_->shutdown();
+        // wsClient has shared_ptr to ChainListener
+        wsClient_.reset();
+    }
 }
 
 std::uint32_t

--- a/src/xbwd/client/ChainListener.h
+++ b/src/xbwd/client/ChainListener.h
@@ -128,7 +128,7 @@ public:
         std::optional<ripple::AccountID> signAccount,
         beast::Journal j);
 
-    virtual ~ChainListener();
+    ~ChainListener() = default;
 
     void
     init(boost::asio::io_service& ios, beast::IP::Endpoint const& ip);

--- a/src/xbwd/client/WebsocketClient.cpp
+++ b/src/xbwd/client/WebsocketClient.cpp
@@ -82,9 +82,12 @@ WebsocketClient::cleanup()
 void
 WebsocketClient::shutdown()
 {
+    if (isShutdown_)
+        return;
     cleanup();
     std::unique_lock l{shutdownM_};
-    shutdownCv_.wait(l, [this] { return isShutdown_.load(); });
+    if (!isShutdown_)
+        shutdownCv_.wait(l, [this] { return isShutdown_.load(); });
 }
 
 WebsocketClient::WebsocketClient(

--- a/src/xbwd/federator/Federator.cpp
+++ b/src/xbwd/federator/Federator.cpp
@@ -552,7 +552,8 @@ Federator::stop()
         }
 
         for (int i = 0; i < lt_last; ++i)
-            threads_[i].join();
+            if (threads_[i].joinable())
+                threads_[i].join();
         running_ = false;
     }
 }


### PR DESCRIPTION
wsClient has shared_ptr to ChainListener,  so during shutdown these 2 objects did not destroyed and would use some functional of the destroyed objects. Which may lead to crash.
The crash can be reproduced if add sleep(1) to main() just before exit