### PR TITLE
Update libxrl to rc3 and rename jobs to be more descriptive

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -58,7 +58,7 @@ jobs:
               version: 14
               cc: /usr/bin/clang-14
               cxx: /usr/bin/clang++-14
-    name: ${{ matrix.compiler }}-${{ matrix.profile.version }} - ${{ matrix.configuration }}
+    name: Dependencies ${{ matrix.compiler }}-${{ matrix.profile.version }} - ${{ matrix.configuration }}
     # runs-on: [self-hosted, x-heavy] # TODO: Use self-host when https://ripplelabs.atlassian.net/browse/RXIT-210 resolved
     runs-on: ubuntu-latest
     container: rippleci/rippled-build-ubuntu:aaf5e3e
@@ -115,7 +115,7 @@ jobs:
           - Release
         cmake-args:
           - ""
-    name: Test ${{ matrix.compiler }}-${{ matrix.configuration }}
+    name: Build & Test ${{ matrix.compiler }}-${{ matrix.configuration }}
     needs: dependencies
     # runs-on: [self-hosted, x-heavy] # TODO: Use self-host when https://ripplelabs.atlassian.net/browse/RXIT-210 resolved
     runs-on: ubuntu-20.04

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 fmt/10.1.1
 openssl/1.1.1u
-xrpl/2.2.0-b2
+xrpl/2.2.0-rc3
 soci/4.0.3
 
 [generators]

--- a/src/xbwd/app/main.cpp
+++ b/src/xbwd/app/main.cpp
@@ -8,7 +8,7 @@
 #include <ripple/beast/core/CurrentThreadName.h>
 #include <ripple/beast/core/SemanticVersion.h>
 #include <ripple/beast/unit_test.h>
-#include <ripple/beast/unit_test/dstream.hpp>
+#include <ripple/beast/unit_test/dstream.h>
 #include <ripple/beast/utility/Journal.h>
 #include <ripple/json/json_reader.h>
 #include <ripple/json/json_value.h>


### PR DESCRIPTION
The jobs are 
1. Build dependencies (which should actually just be downloads)
2. Build and run unit tests for `xbridge_witnessd`

Update to use the latest libxprl (which requires renaming a header included.)
