### PR TITLE
RXI-1122 fix history mode after reconnect

### DIFF
--- a/src/xbwd/client/ChainListener.cpp
+++ b/src/xbwd/client/ChainListener.cpp
@@ -131,12 +131,17 @@ ChainListener::onConnect()
 
     // Clear on re-connect
     inRequest_ = false;
-    ledgerReqMax_ = 0;
-    ledgerProcessedDoor_ = 0;
-    ledgerProcessedSubmit_ = 0;
-    prevLedgerIndex_ = 0;
-    txnHistoryIndex_ = 0;
-    hp_.clear();
+
+    // Resume only if history finished
+    if (hp_.state_ != HistoryProcessor::FINISHED)
+    {
+        ledgerReqMax_ = 0;
+        ledgerProcessedDoor_ = 0;
+        ledgerProcessedSubmit_ = 0;
+        prevLedgerIndex_ = 0;
+        txnHistoryIndex_ = 0;
+        hp_.clear();
+    }
 
     if (signAccount_)
     {


### PR DESCRIPTION
Currently after reconnect ChainListener reset to history mode and start initialization from the beginning, but Federator  - not. So this PR reset ChainListener only if current state is History processing. If not - it will resume processing ledgers from where it stops. So the server will continue like it was additional delay in retrieving ledgers.
Also added fixes to websocket client so it will not try to send messages during reconnect.